### PR TITLE
Explicitly setting method to get on GET method for when class instance is reused to not use post again if previously called.

### DIFF
--- a/src/anlutro/cURL/cURL.php
+++ b/src/anlutro/cURL/cURL.php
@@ -31,7 +31,7 @@ class cURL
 	 *
 	 * @var string
 	 */
-	protected $method = 'get';
+	protected $method;
 
 	/**
 	 * The last response in its original form.


### PR DESCRIPTION
I had an issue with your cURL class when it was used in an IoC container in Laravel. By doing this, users will not have to create another instance or use the POST method again if it was previously called earlier on in the runtime.
