### PR TITLE
Added response object

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,15 +13,15 @@ https://packagist.org/packages/anlutro/curl
 $curl = new anlutro\cURL\cURL;
 
 // the raw body from the response is returned
-$html = $curl->get('http://www.google.com');
+$html = $curl->get('http://www.google.com')->body;
 
 // easily build an url with a query string
 $url = $curl->buildUrl('http://www.google.com', ['s' => 'curl']);
-$html = $curl->get($url);
+$html = $curl->get($url)->body;
 
 // post() takes an array of POST data
 $url = $curl->buildUrl('http://api.myservice.com', ['api_key' => 'my_api_key']);
-$data = $curl->post($url, ['post' => 'data']);
+$data = $curl->post($url, ['post' => 'data'])->body;
 
 // add a header before sending a request
 $curl->addHeader('Authorization: Basic QWxhZGRpbjpvcGVuIHNlc2FtZQ==');
@@ -31,4 +31,9 @@ $allHeaders = $curl->getHeaders();
 $header = $curl->getHeaders('Accept-Charset');
 ```
 
-Comes with a Laravel service provider and facade. Add `anlutro\cURL\Laravel\cURLServiceProvider` to the array of providers in `app/config/app.php`, and (optionally) add `'cURL' => 'anlutro\cURL\Laravel\cURL'` to the array of aliases in the same file.
+## Laravel Service Provider
+cURL comes with a Laravel service provider and facade.
+
+Add `anlutro\cURL\Laravel\cURLServiceProvider` to the array of providers in `app/config/app.php`.
+
+And (optionally) add `'cURL' => 'anlutro\cURL\Laravel\cURL'` to the array of aliases in the same file.

--- a/src/anlutro/cURL/Response.php
+++ b/src/anlutro/cURL/Response.php
@@ -1,0 +1,87 @@
+<?php
+/**
+ * PHP OOP cURL
+ * 
+ * @author   Andreas Lutro <anlutro@gmail.com>
+ * @license  http://opensource.org/licenses/MIT
+ * @package  PHP cURL
+ */
+
+namespace anlutro\cURL;
+
+/**
+ * cURL wrapper class.
+ */
+class Response
+{
+	/**
+	 * The response headers.
+	 *
+	 * @var array
+	 */
+	public $headers = array();
+
+	/**
+	 * The response body.
+	 *
+	 * @var string
+	 */
+	public $body;
+
+	/**
+	 * The results of curl_getinfo on the response request.
+	 *
+	 * @var array|false
+	 */
+	public $info;
+
+	/**
+	 * Create a new Eloquent model instance.
+	 *
+	 * @param  array  $attributes
+	 * @return void
+	 */
+	public function __construct($body, $headers, $info)
+	{
+		$this->body = $body;
+		$this->headers = $headers;
+		$this->info = $info;
+	}
+
+	/**
+	 * Get all or a specific header from the last curl statement.
+	 *
+	 * @param  string $header Name of the header to get. If not provided, gets
+	 * all headers from the last response.
+	 *
+	 * @return array
+	 */
+	public function getHeader($key)
+	{
+		return $this->headers[$key];
+	}
+
+	/**
+	 * Convert the model instance to an array.
+	 *
+	 * @return array
+	 */
+	public function toArray()
+	{
+		return array(
+			'headers' => $this->headers,
+			'body' => $this->body,
+			'info' => $this->info
+		);
+	}
+
+	/**
+	 * Convert the object to its string representation, by returning responseBody as string.
+	 *
+	 * @return string
+	 */
+	public function __toString()
+	{
+		return $this->body;
+	}
+}


### PR DESCRIPTION
This gives easy access to response headers and info when using facades.

```
$response = CURL::get('www.example.com/file.jpg')
$body = $response->body;
$headers = $response->headers;
$info = $response->info;
```

Also if you pass the response object to something that needs a string the body will simply be passed.
