### PR TITLE
implement "raw" requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,9 @@ $response = $curl->post($url, ['post' => 'data']);
 // add "json" to the start of the method to post as JSON
 $response = $curl->jsonPut($url, ['post' => 'data']);
 
+// add "raw" to the start of the method to post raw data
+$response = $curl->rawPost($url, '<?xml version...');
+
 // a response object is returned
 var_dump($response->code); // response status code (for example, '200 OK')
 echo $response->body;

--- a/src/anlutro/cURL/Request.php
+++ b/src/anlutro/cURL/Request.php
@@ -19,6 +19,7 @@ class Request
 	 */
 	const ENCODING_URL = 0;
 	const ENCODING_JSON = 1;
+	const ENCODING_RAW = 3;
 
 	/**
 	 * The HTTP method to use. Defaults to GET.
@@ -195,9 +196,9 @@ class Request
 	/**
 	 * Set the POST data to be sent with the request.
 	 *
-	 * @param array $data
+	 * @param mixed $data
 	 */
-	public function setData(array $data)
+	public function setData($data)
 	{
 		$this->data = $data;
 
@@ -273,6 +274,10 @@ class Request
 				return json_encode($this->data);
 				break;
 
+			case Request::ENCODING_RAW:
+				return (string)$this->data;
+				break;
+
 			case Request::ENCODING_URL:
 			default:
 				return http_build_query($this->data);
@@ -299,6 +304,7 @@ class Request
 	{
 		$encoding = intval($encoding);
 		switch( $encoding ){
+			case Request::ENCODING_RAW:
 			case Request::ENCODING_URL:
 				$this->encoding = $encoding;
 				break;

--- a/src/anlutro/cURL/cURL.php
+++ b/src/anlutro/cURL/cURL.php
@@ -101,12 +101,12 @@ class cURL
 	 *
 	 * @param  string  $method    get, post, etc
 	 * @param  string  $url
-	 * @param  array   $data      POST data
+	 * @param  mixed   $data      POST data
 	 * @param  int     $encoding  Request::ENCODING_* constant specifying how to process the POST data
 	 *
 	 * @return mixed
 	 */
-	public function newRequest($method, $url, array $data = array(), $encoding = Request::ENCODING_URL)
+	public function newRequest($method, $url, $data = array(), $encoding = Request::ENCODING_URL)
 	{
 		$class = $this->requestClass;
 		$request = new $class($this);
@@ -131,6 +131,20 @@ class cURL
 	public function newJsonRequest($method, $url, array $data = array())
 	{
 		return $this->newRequest($method, $url, $data, Request::ENCODING_JSON);
+	}
+
+	/**
+	 * Create a new raw request and set its values.
+	 *
+	 * @param  string $method  get, post etc
+	 * @param  string $url
+	 * @param  array  $data    POST data
+	 *
+	 * @return mixed
+	 */
+	public function newRawRequest($method, $url, $data = '')
+	{
+		return $this->newRequest($method, $url, $data, Request::ENCODING_RAW);
 	}
 
 	/**
@@ -259,6 +273,9 @@ class cURL
 		if (substr($method, 0, 4) === 'json') {
 			$encoding = Request::ENCODING_JSON;
 			$method = substr($method, 4);
+		} elseif (substr($method, 0, 3) === 'raw') {
+			$encoding = Request::ENCODING_RAW;
+			$method = substr($method, 3);
 		}
 
 		if (!array_key_exists($method, $this->methods)) {

--- a/tests/RequestTest.php
+++ b/tests/RequestTest.php
@@ -36,6 +36,10 @@ class RequestTest extends PHPUnit_Framework_TestCase
 
 		$r->setEncoding(anlutro\cURL\Request::ENCODING_JSON);
 		$this->assertEquals('{"foo":"bar","bar":"baz"}', $r->encodeData());
+
+		$r->setEncoding(anlutro\cURL\Request::ENCODING_RAW);
+		$r->setData('<rawData>ArbitraryValue</rawData>');
+		$this->assertEquals('<rawData>ArbitraryValue</rawData>', $r->encodeData());
 	}
 
 	public function testJsonConvenienceMethod()

--- a/tests/cURLTest.php
+++ b/tests/cURLTest.php
@@ -13,6 +13,28 @@ class cURLTest extends PHPUnit_Framework_TestCase
 		$this->assertNotNull($r->info);
 	}
 
+	public function testConvenienceBuilders()
+	{
+		$curl = $this->makeCurl();
+		$r = $curl->newRequest('get', 'https://www.php.net', array('foo' => 'bar'));
+		$this->assertEquals('get', $r->getMethod());
+		$this->assertEquals('https://www.php.net', $r->getUrl());
+		$this->assertEquals(array('foo' => 'bar'), $r->getData());
+		$this->assertEquals(\anlutro\cURL\Request::ENCODING_URL, $r->getEncoding());
+
+		$r = $curl->newJsonRequest('get', 'https://www.php.net', array('foo' => 'bar'));
+		$this->assertEquals('get', $r->getMethod());
+		$this->assertEquals('https://www.php.net', $r->getUrl());
+		$this->assertEquals(array('foo' => 'bar'), $r->getData());
+		$this->assertEquals(\anlutro\cURL\Request::ENCODING_JSON, $r->getEncoding());
+
+		$r = $curl->newRawRequest('get', 'https://www.php.net', array('foo' => 'bar'));
+		$this->assertEquals('get', $r->getMethod());
+		$this->assertEquals('https://www.php.net', $r->getUrl());
+		$this->assertEquals(array('foo' => 'bar'), $r->getData());
+		$this->assertEquals(\anlutro\cURL\Request::ENCODING_RAW, $r->getEncoding());
+	}
+
 	public function makeCurl()
 	{
 		return new \anlutro\cURL\cURL;


### PR DESCRIPTION
This attempts to provide a solution for sending "raw" requests via the cURL class, for use in APIs (such as the eBay trading API) which do not expect POST data to be in the form of URL parameters, and instead accept raw XML.

It is worth noting that these changes are technically incompatible with version 0.5.0: Though older code which passes a boolean to the ->setJson() and ->newRequest() methods will continue to work, any code which operated on truthy-numbers (eg: 1 vs 3) may not work with this version of the code.

in summary:
 $r->setJson(TRUE);  // still works
 $r->setJson(17); // previously set Json to 'true', now throws an InvalidArgument exception
