### PR TITLE
remove the (string) coercion for raw POST data

### DIFF
--- a/src/Request.php
+++ b/src/Request.php
@@ -274,7 +274,7 @@ class Request
 				return json_encode($this->data);
 
 			case Request::ENCODING_RAW:
-				return (string) $this->data;
+				return $this->data;
 
 			case Request::ENCODING_QUERY:
 				return http_build_query($this->data);


### PR DESCRIPTION
when the "RAW" format was added, it was intended for sending literally
raw, uninterpreted data, via HTTP POST. To document this intent, a
(string) coercion for the data was added.

In order to add support for file uploads, the coercion is removed,
allowing one to pass in an array of key->value pairs, to be interpreted
by cURL appropriately. Specifically, this allows the use of the
'file' => '@/path/to/file' format, which would be escaped by the
query-string encoding if not using RAW format, and which must be passed
as an array, not pre-formatted string, in order to be interpreted by
cURL.
