### PR TITLE
Allows HTTP Basic Auth with username only

### DIFF
--- a/src/Request.php
+++ b/src/Request.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * PHP OOP cURL
- * 
+ *
  * @author   Andreas Lutro <anlutro@gmail.com>
  * @license  http://opensource.org/licenses/MIT
  * @package  PHP cURL
@@ -162,7 +162,7 @@ class Request
 
 	/**
 	 * Set the headers to be sent with the request.
-	 * 
+	 *
 	 * Pass an associative array - e.g. ['Content-Type' => 'application/json']
 	 * and the correct header formatting - e.g. 'Content-Type: application/json'
 	 * will be done for you when the request is sent.
@@ -466,7 +466,7 @@ class Request
 	 */
 	public function getUserAndPass()
 	{
-		if ($this->user && $this->pass) {
+		if ($this->user) {
 			return $this->user . ':' . $this->pass;
 		}
 

--- a/tests/unit/RequestTest.php
+++ b/tests/unit/RequestTest.php
@@ -96,7 +96,7 @@ class RequestTest extends PHPUnit_Framework_TestCase
 		$r = $this->makeRequest();
 		$this->assertEquals(null, $r->getUserAndPass());
 		$r->setUser('foo');
-		$this->assertEquals(null, $r->getUserAndPass());
+		$this->assertEquals('foo:', $r->getUserAndPass());
 		$r->setPass('bar');
 		$this->assertEquals('foo:bar', $r->getUserAndPass());
 	}


### PR DESCRIPTION
Because it seems that many APIs work with HTTP Basic Auth with username only (ex: [Streak API](https://www.streak.com/api/#authentication)).