### PR TITLE
Support for sending a json request with empty body

### DIFF
--- a/src/Request.php
+++ b/src/Request.php
@@ -397,7 +397,7 @@ class Request
 			case static::ENCODING_JSON:
 				return json_encode($this->data);
 			case static::ENCODING_QUERY:
-				return http_build_query($this->data);
+				return (!is_null($this->data) ? http_build_query($this->data) : '');
 			case static::ENCODING_RAW:
 				return $this->data;
 			default:

--- a/src/Request.php
+++ b/src/Request.php
@@ -337,7 +337,7 @@ class Request
 	 */
 	public function hasData()
 	{
-		return (bool) $this->data;
+		return (bool) $this->encodeData();
 	}
 
 	/**

--- a/src/cURL.php
+++ b/src/cURL.php
@@ -255,11 +255,7 @@ class cURL
 		}
 
 		$method = $request->getMethod();
-		if ($method === 'post') {
-			curl_setopt($this->ch, CURLOPT_POST, 1);
-		} elseif ($method !== 'get') {
-			curl_setopt($this->ch, CURLOPT_CUSTOMREQUEST, strtoupper($method));
-		}
+		curl_setopt($this->ch, CURLOPT_CUSTOMREQUEST, strtoupper($method));
 
 		curl_setopt($this->ch, CURLOPT_HTTPHEADER, $request->formatHeaders());
 
@@ -355,7 +351,7 @@ class cURL
 		if (isset($args[1])) {
 			$data = $args[1];
 		} else {
-			$data = array();
+			$data = null;
 		}
 
 		$request = $this->newRequest($method, $url, $data, $encoding);

--- a/src/cURL.php
+++ b/src/cURL.php
@@ -355,7 +355,7 @@ class cURL
 		if (isset($args[1])) {
 			$data = $args[1];
 		} else {
-			$data = null;
+			$data = array();
 		}
 
 		$request = $this->newRequest($method, $url, $data, $encoding);

--- a/tests/functional/cURLTest.php
+++ b/tests/functional/cURLTest.php
@@ -52,6 +52,20 @@ class cURLTest extends PHPUnit_Framework_TestCase
 	}
 
 	/** @test */
+	public function queryRequestEmptyArrayBody()
+	{
+		$r = $this->makeCurl()->post(static::URL.'/echo.php', array());
+		$this->assertEquals('', $r->body);
+	}
+
+	/** @test */
+	public function queryRequestEmptyObjectBody()
+	{
+		$r = $this->makeCurl()->post(static::URL.'/echo.php', new \stdClass());
+		$this->assertEquals('', $r->body);
+	}
+
+	/** @test */
 	public function jsonRequestBody()
 	{
 		$r = $this->makeCurl()->jsonPost(static::URL.'/echo.php', array('foo' => 'bar'));
@@ -59,10 +73,17 @@ class cURLTest extends PHPUnit_Framework_TestCase
 	}
 
 	/** @test */
-	public function jsonRequestEmptyBody()
+	public function jsonRequestEmptyArrayBody()
 	{
-		$r = $this->makeCurl()->jsonPost(static::URL.'/echo.php', []);
+		$r = $this->makeCurl()->jsonPost(static::URL.'/echo.php', array());
 		$this->assertEquals('[]', $r->body);
+	}
+
+	/** @test */
+	public function jsonRequestEmptyObjectBody()
+	{
+		$r = $this->makeCurl()->jsonPost(static::URL.'/echo.php', new \stdClass());
+		$this->assertEquals('{}', $r->body);
 	}
 
 	/** @test */
@@ -70,6 +91,13 @@ class cURLTest extends PHPUnit_Framework_TestCase
 	{
 		$r = $this->makeCurl()->rawPost(static::URL.'/echo.php', '<foo/>');
 		$this->assertEquals('<foo/>', $r->body);
+	}
+
+	/** @test */
+	public function rawRequestEmptyBody()
+	{
+		$r = $this->makeCurl()->rawPost(static::URL.'/echo.php', '');
+		$this->assertEquals('', $r->body);
 	}
 
 	/** @test */

--- a/tests/functional/cURLTest.php
+++ b/tests/functional/cURLTest.php
@@ -59,6 +59,13 @@ class cURLTest extends PHPUnit_Framework_TestCase
 	}
 
 	/** @test */
+	public function jsonRequestEmptyBody()
+	{
+		$r = $this->makeCurl()->jsonPost(static::URL.'/echo.php', []);
+		$this->assertEquals('[]', $r->body);
+	}
+
+	/** @test */
 	public function rawRequestBody()
 	{
 		$r = $this->makeCurl()->rawPost(static::URL.'/echo.php', '<foo/>');


### PR DESCRIPTION
Otherwise a malformed request is sent (body does not match content-length header)