### PR TITLE
Add support for digest authentication

### DIFF
--- a/src/Response.php
+++ b/src/Response.php
@@ -108,6 +108,20 @@ class Response
 			return $this->parseHeaders($headers);
 		}
 
+		// special handling for HTTP 401 responses containing multiple statuses (e.g. digest authentication)
+		if ($code === 401 && !empty(preg_grep('/^HTTP\/\d(\.\d)? [0-9]{3}/', $headers))) {
+			// remove header lines between 401 and actual HTTP status
+			foreach ($headers as $key => $header) {
+				if (preg_match('/^HTTP\/\d(\.\d)? [0-9]{3}/', $header)) {
+					break;
+				}
+				unset($headers[$key]);
+			}
+
+			// start the process over with the 401 unauthorized header stripped away
+			return $this->parseHeaders($headers);
+		}
+
 		$this->statusText = $status;
 		$this->statusCode = $code;
 

--- a/tests/unit/ResponseTest.php
+++ b/tests/unit/ResponseTest.php
@@ -57,6 +57,15 @@ class ResponseTest extends PHPUnit_Framework_TestCase
 	}
 
 	/** @test */
+	public function httpUnauthorizedResponsesContainingMultipleStatusesAreHandled()
+	{
+		$header = "HTTP/1.1 401 Unauthorized\r\nx-var: foo\r\n\r\nHTTP/1.1 200 OK\r\nx-var: bar";
+		$r = $this->makeResponse('', $header);
+		$this->assertEquals(200, $r->statusCode);
+		$this->assertEquals('bar', $r->getHeader('x-var'));
+	}
+
+	/** @test */
 	public function throwsExceptionIfHeaderDoesntStartWithHttpStatus()
 	{
 		$this->setExpectedException('InvalidArgumentException', 'Invalid response header');


### PR DESCRIPTION
When I used this library with digest authentication, I encountered a issue that the return value of the `Response::statusCode` method was 401 regardless of success or failure.

In the case of digest authentication, it seems that the 401 is returned first and then the real status code.

I have changed it to set the last status code.