### PR TITLE
add support for CURLOPT_HTTPAUTH, digest etc.

### DIFF
--- a/src/Response.php
+++ b/src/Response.php
@@ -109,7 +109,11 @@ class Response
 
 		// handle cases where CURLOPT_HTTPAUTH is being used, in which case
 		// curl_exec may cause two HTTP responses
-		if ($this->info[CURLINFO_HTTPAUTH_AVAIL] > 0 && $code === 401) {
+		if (
+			array_key_exists(CURLINFO_HTTPAUTH_AVAIL, $this->info) &&
+			$this->info[CURLINFO_HTTPAUTH_AVAIL] > 0 &&
+			$code === 401
+		) {
 			$foundAuthenticateHeader = false;
 			$foundSecondHttpResponse = false;
 			foreach ($headers as $idx => $header) {

--- a/src/cURL.php
+++ b/src/cURL.php
@@ -308,6 +308,8 @@ class cURL
 	{
 		$info = curl_getinfo($this->ch);
 		$headerSize = curl_getinfo($this->ch, CURLINFO_HEADER_SIZE);
+		// needed for the Response class to know that it may have to parse 2 HTTP responses
+		$info[CURLINFO_HTTPAUTH_AVAIL] = curl_getinfo($this->ch, CURLINFO_HTTPAUTH_AVAIL);
 
 		$headers = substr($response, 0, $headerSize);
 		$body = substr($response, $headerSize);

--- a/tests/functional/cURLTest.php
+++ b/tests/functional/cURLTest.php
@@ -115,6 +115,17 @@ class cURLTest extends PHPUnit_Framework_TestCase
 	}
 
 	/** @test */
+	public function digestAuth()
+	{
+		$curl = $this->makeCurl();
+		$request = $curl->newRequest('get', static::URL . '/digest-auth.php');
+		$request->auth('guest', 'guest');
+		$request->setOption(CURLOPT_HTTPAUTH, CURLAUTH_DIGEST);
+		$response = $curl->sendRequest($request);
+		$this->assertEquals(200, $response->statusCode);
+	}
+
+	/** @test */
 	public function throwsExceptionOnCurlError()
 	{
 		$this->setExpectedException('anlutro\cURL\cURLException', 'cURL request failed with error [7]:');
@@ -140,7 +151,7 @@ class cURLTest extends PHPUnit_Framework_TestCase
 	{
 		$curl = $this->makeCurl();
 		$curl->setDefaultHeaders(array('foo' => 'bar'));
-		$request = $curl->newRequest('post', 'localhost');
+		$request = $curl->newRequest('post', 'does-not-matter');
 		$this->assertEquals('bar', $request->getHeader('foo'));
 	}
 
@@ -149,7 +160,7 @@ class cURLTest extends PHPUnit_Framework_TestCase
 	{
 		$curl = $this->makeCurl();
 		$curl->setDefaultOptions(array('foo' => 'bar'));
-		$request = $curl->newRequest('post', 'localhost');
+		$request = $curl->newRequest('post', 'does-not-matter');
 		$this->assertEquals('bar', $request->getOption('foo'));
 	}
 }

--- a/tests/server/digest-auth.php
+++ b/tests/server/digest-auth.php
@@ -1,0 +1,53 @@
+<?php
+// copy-pasted from https://www.php.net/manual/en/features.http-auth.php
+
+$realm = 'Restricted area';
+
+//user => password
+$users = array('admin' => 'mypass', 'guest' => 'guest');
+
+
+if (empty($_SERVER['PHP_AUTH_DIGEST'])) {
+    header('HTTP/1.1 401 Unauthorized');
+    header('WWW-Authenticate: Digest realm="'.$realm.
+           '",qop="auth",nonce="'.uniqid().'",opaque="'.md5($realm).'"');
+
+    die('Text to send if user hits Cancel button');
+}
+
+
+// analyze the PHP_AUTH_DIGEST variable
+if (!($data = http_digest_parse($_SERVER['PHP_AUTH_DIGEST'])) ||
+    !isset($users[$data['username']]))
+    die('Wrong Credentials!');
+
+
+// generate the valid response
+$A1 = md5($data['username'] . ':' . $realm . ':' . $users[$data['username']]);
+$A2 = md5($_SERVER['REQUEST_METHOD'].':'.$data['uri']);
+$valid_response = md5($A1.':'.$data['nonce'].':'.$data['nc'].':'.$data['cnonce'].':'.$data['qop'].':'.$A2);
+
+if ($data['response'] != $valid_response)
+    die('Wrong Credentials!');
+
+// ok, valid username & password
+echo 'You are logged in as: ' . $data['username'];
+
+
+// function to parse the http auth header
+function http_digest_parse($txt)
+{
+    // protect against missing data
+    $needed_parts = array('nonce'=>1, 'nc'=>1, 'cnonce'=>1, 'qop'=>1, 'username'=>1, 'uri'=>1, 'response'=>1);
+    $data = array();
+    $keys = implode('|', array_keys($needed_parts));
+
+    preg_match_all('@(' . $keys . ')=(?:([\'"])([^\2]+?)\2|([^\s,]+))@', $txt, $matches, PREG_SET_ORDER);
+
+    foreach ($matches as $m) {
+        $data[$m[1]] = $m[3] ? $m[3] : $m[4];
+        unset($needed_parts[$m[1]]);
+    }
+
+    return $needed_parts ? false : $data;
+}

--- a/tests/unit/ResponseTest.php
+++ b/tests/unit/ResponseTest.php
@@ -62,4 +62,13 @@ class ResponseTest extends PHPUnit_Framework_TestCase
 		$this->setExpectedException('InvalidArgumentException', 'Invalid response header');
 		$this->makeResponse('', 'x-var: foo');
 	}
+
+	/** @test */
+	public function httpUnauthorizedResponsesContainingMultipleStatusesAreHandled()
+	{
+		$header = "HTTP/1.1 401 Unauthorized\r\nwww-authenticate: digest something\r\n\r\nHTTP/1.1 200 OK\r\nx-var: foo";
+		$r = $this->makeResponse('', $header, [CURLINFO_HTTPAUTH_AVAIL => CURLAUTH_DIGEST]);
+		$this->assertEquals(200, $r->statusCode);
+		$this->assertEquals('foo', $r->getHeader('x-var'));
+	}
 }


### PR DESCRIPTION
with CURLOPT_HTTPAUTH it's possible for libcurl to return multiple responses - the first one a 401, the second one a potentially successful response. especially with digest auth or other negotiation-based authentication mechanisms.

replaces #62 