### PR TITLE
fixes for `CURLOPT_FILE` handling

### DIFF
--- a/src/Response.php
+++ b/src/Response.php
@@ -70,6 +70,9 @@ class Response
 	 */
 	protected function parseHeader($header)
 	{
+		if ($header === "") {
+			throw new \UnexpectedValueException('Empty header string passed!');
+		}
 		$headers = explode("\r\n", trim($header));
 		$this->parseHeaders($headers);
 	}
@@ -83,12 +86,16 @@ class Response
 	 */
 	protected function parseHeaders(array $headers)
 	{
+		if (count($headers) === 0) {
+			throw new \UnexpectedValueException('No headers passed!');
+		}
+
 		$this->headers = array();
 
 		// find and set the HTTP status code and reason
 		$firstHeader = array_shift($headers);
 		if (!preg_match('/^HTTP\/\d(\.\d)? [0-9]{3}/', $firstHeader)) {
-			throw new \InvalidArgumentException('Invalid response header');
+			throw new \UnexpectedValueException('Invalid response header');
 		}
 		list(, $status) = explode(' ', $firstHeader, 2);
 		$code = explode(' ', $status);

--- a/src/cURL.php
+++ b/src/cURL.php
@@ -313,15 +313,12 @@ class cURL
 		$info[CURLINFO_HTTPAUTH_AVAIL] = curl_getinfo($this->ch, CURLINFO_HTTPAUTH_AVAIL);
 
 		if ($file = $request->getOption(CURLOPT_FILE)) {
-			// TODO: is this even possible?
-			if (!is_resource($file)) {
-				$file = fopen($file, "r");
-			}
-			// TODO: what if resource isn't seekable? e.g. network socket?
-			$oldPosition = ftell($file);
-			fseek($file, 0);
+			// file may be opened write-only, and even when it isn't,
+			// seeking/reading seems to be buggy
+			$fileMeta = stream_get_meta_data($file);
+			$file = fopen($fileMeta['uri'], 'r');
 			$headers = fread($file, $headerSize);
-			fseek($file, $oldPosition);
+			fclose($file);
 			$body = null;
 		} else {
 			$headers = substr($response, 0, $headerSize);

--- a/tests/functional/cURLTest.php
+++ b/tests/functional/cURLTest.php
@@ -169,7 +169,7 @@ class cURLTest extends PHPUnit_Framework_TestCase
 	{
 		$r = $this->makeCurl()
 			->newRequest('get', static::URL.'/success.php')
-			->setOption(CURLOPT_FILE, tmpfile())
+			->setOption(CURLOPT_FILE, $fh = tmpfile())
 			->send();
 		$this->assertEquals(200, $r->statusCode);
 		$this->assertEquals('200 OK', $r->statusText);

--- a/tests/unit/ResponseTest.php
+++ b/tests/unit/ResponseTest.php
@@ -59,7 +59,7 @@ class ResponseTest extends PHPUnit_Framework_TestCase
 	/** @test */
 	public function throwsExceptionIfHeaderDoesntStartWithHttpStatus()
 	{
-		$this->setExpectedException('InvalidArgumentException', 'Invalid response header');
+		$this->setExpectedException('UnexpectedValueException', 'Invalid response header');
 		$this->makeResponse('', 'x-var: foo');
 	}
 


### PR DESCRIPTION
seems like re-using the file handler set with `CURLOPT_FILE` doesn't work reliably.

closes #65