### PR TITLE
correct http2 test

### DIFF
--- a/tests/unit/ResponseTest.php
+++ b/tests/unit/ResponseTest.php
@@ -24,9 +24,9 @@ class ResponseTest extends PHPUnit_Framework_TestCase
 	/** @test */
 	public function parsesHttp2ResponseCorrectly()
 	{
-		$r = $this->makeResponse('', 'HTTP/2 200 OK');
+		$r = $this->makeResponse('', 'HTTP/2 200');
 		$this->assertEquals(200, $r->statusCode);
-		$this->assertEquals('200 OK', $r->statusText);
+		$this->assertEquals('200', $r->statusText);
 	}
 
 	/** @test */


### PR DESCRIPTION
turns out that http2 responses do not contain the status text, e.g. "OK":

```
$ curl -I https://httpbin.org/get
HTTP/2 200 
date: Wed, 14 Jul 2021 16:07:26 GMT
content-type: application/json
content-length: 256
server: gunicorn/19.9.0
access-control-allow-origin: *
access-control-allow-credentials: true
```