### PR TITLE
Fix: Dynamic property Request::$curl assignment is deprecated in PHP 8.2

### DIFF
--- a/src/Request.php
+++ b/src/Request.php
@@ -36,6 +36,13 @@ class Request
 		'options' => false,
 	);
 
+    /**
+     * cURL wrapper instance
+     *
+     * @var cURL
+     */
+    private $curl;
+
 	/**
 	 * The HTTP method to use. Defaults to GET.
 	 *


### PR DESCRIPTION
This PR removes deprecation notice emitted on PHP 8.2